### PR TITLE
Remove hardcoded full paths to icons from desktop files

### DIFF
--- a/doc/qnapi-download.desktop
+++ b/doc/qnapi-download.desktop
@@ -3,7 +3,7 @@ Version=1.0
 Actions=QNapiDownload;
 Name=Pobierz napisy do filmu z QNapi
 GenericName=Pobierz napisy do filmu z QNapi
-Icon=/usr/share/icons/qnapi-48.png
+Icon=qnapi-48
 ServiceTypes=video/x-msvideo,video/x-ms-asf,video/mpeg,video/x-ms-wmv,video/mp4,video/quicktime,video/x-theora,video/x-matroska,video/3gpp,application/vnd.rn-realmedia,application/vnd.rn-realmedia-vbr
 X-KDE-ServiceTypes=KonqPopupMenu/Plugin
 Type=Service
@@ -11,4 +11,4 @@ Type=Service
 [Desktop Action QNapiDownload]
 Name=Pobierz napisy do filmu z QNapi
 Exec=qnapi %F
-Icon=/usr/share/icons/qnapi-48.png
+Icon=qnapi-48

--- a/doc/qnapi-scan.desktop
+++ b/doc/qnapi-scan.desktop
@@ -3,7 +3,7 @@ Version=1.0
 Actions=QNapiScan;
 Name=Przeskanuj katalog i pobierz napisy
 GenericName=Przeskanuj katalogu i pobierz napisy
-Icon=/usr/share/icons/qnapi-48.png
+Icon=qnapi-48
 ServiceTypes=inode/directory
 X-KDE-ServiceTypes=KonqPopupMenu/Plugin
 Type=Service
@@ -11,4 +11,4 @@ Type=Service
 [Desktop Action QNapiScan]
 Name=Przeskanuj katalog i pobierz napisy
 Exec=qnapi %U
-Icon=/usr/share/icons/qnapi-48.png
+Icon=qnapi-48

--- a/doc/qnapi.desktop
+++ b/doc/qnapi.desktop
@@ -1,9 +1,9 @@
 [Desktop Entry]
 Exec=qnapi
 Name=QNapi
-Icon=/usr/share/icons/qnapi-48.png
+Icon=qnapi-48
 Type=Application
-Categories=AudioVideo
+Categories=AudioVideo;
 Comment=Program do pobierania napisów do filmów
 GenericName=Program do pobierania napisów do filmów
 Terminal=false


### PR DESCRIPTION
This fixes icons for installations when INSTALL_PREFIX != /usr. According to:
http://standards.freedesktop.org/icon-theme-spec/icon-theme-spec-latest.html
icons installed to ${PREFIX]/share/icons not need to have full paths in desktop files.
I use this patch on my system and all icons show up as expected.

Also there are similar icons paths hardcoded in schema files, but I don't if it's ok to remove
them too so I left them alone.

