### PR TITLE
Przekazywanie nazwy pliku za pomocą aktywatora

### DIFF
--- a/doc/qnapi.desktop
+++ b/doc/qnapi.desktop
@@ -1,5 +1,5 @@
 [Desktop Entry]
-Exec=qnapi
+Exec=qnapi %U
 Name=QNapi
 Icon=qnapi
 Type=Application


### PR DESCRIPTION
Dodałem parametr przekazujący ścieżkę w pliku .desktop. Dzięki temu aktywator programu wyświetlany jest na liście programów potrafiących otworzyć wskazany plik i można wyszukać napisy dla wskazanego pliku z poziomu menedżera plików, z użyciem polecenia otwierania za pomocą innego programu.