### PR TITLE
Consistently use the 'remove_words_enabled' setting

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -75,7 +75,7 @@ before_install:
   - if [[ "$QT_BASE" = "56" && "$TRAVIS_OS_NAME" = "linux" ]]; then sudo add-apt-repository ppa:beineri/opt-qt562-trusty -y; fi
   - if [[ "$QT_BASE" = "57" && "$TRAVIS_OS_NAME" = "linux" ]]; then sudo add-apt-repository ppa:beineri/opt-qt571-trusty -y; fi
   - if [[ "$QT_BASE" = "58" && "$TRAVIS_OS_NAME" = "linux" ]]; then sudo add-apt-repository ppa:beineri/opt-qt58-trusty -y; fi
-  - if [[ "$QT_BASE" = "59" && "$TRAVIS_OS_NAME" = "linux" ]]; then sudo add-apt-repository ppa:beineri/opt-qt59-trusty -y; fi
+  - if [[ "$QT_BASE" = "59" && "$TRAVIS_OS_NAME" = "linux" ]]; then sudo add-apt-repository ppa:beineri/opt-qt593-trusty -y; fi
   - if [ "$TRAVIS_OS_NAME" = "linux" ]; then 
       sudo apt-get update -qq;
     else

--- a/gui/src/forms/frmoptions.cpp
+++ b/gui/src/forms/frmoptions.cpp
@@ -379,7 +379,7 @@ void frmOptions::writeConfig() {
           .setEncodingFrom(ui.cbEncFrom->currentText())
           .setEncodingTo(ui.cbEncTo->currentText())
           .setShowAllEncodings(ui.cbShowAllEncodings->isChecked())
-          .setRemoveWordsEnabled(ui.cbRemoveLines->isChecked())
+          .setRemoveLines(ui.cbRemoveLines->isChecked())
           .setRemoveWords(ui.teRemoveWords->toPlainText().split("\n"))
           .setSubFormat(targetSubFormat)
           .setSubExtension(targetSubExt)
@@ -456,7 +456,7 @@ void frmOptions::readConfig(const QNapiConfig &config) {
   ui.cbShowAllEncodings->setChecked(
       config.postProcessingConfig().showAllEncodings());
   ui.cbRemoveLines->setChecked(
-      config.postProcessingConfig().removeWordsEnabled());
+      config.postProcessingConfig().removeLines());
   ui.teRemoveWords->setText(
       config.postProcessingConfig().removeWords().join("\n"));
 

--- a/gui/src/forms/frmoptions.cpp
+++ b/gui/src/forms/frmoptions.cpp
@@ -380,7 +380,7 @@ void frmOptions::writeConfig() {
           .setEncodingTo(ui.cbEncTo->currentText())
           .setShowAllEncodings(ui.cbShowAllEncodings->isChecked())
           .setRemoveLines(ui.cbRemoveLines->isChecked())
-          .setRemoveWords(ui.teRemoveWords->toPlainText().split("\n"))
+          .setRemoveLinesWords(ui.teRemoveLinesWords->toPlainText().split("\n"))
           .setSubFormat(targetSubFormat)
           .setSubExtension(targetSubExt)
           .setSkipConvertAds(ui.cbSkipConvertAds->isChecked());
@@ -457,8 +457,8 @@ void frmOptions::readConfig(const QNapiConfig &config) {
       config.postProcessingConfig().showAllEncodings());
   ui.cbRemoveLines->setChecked(
       config.postProcessingConfig().removeLines());
-  ui.teRemoveWords->setText(
-      config.postProcessingConfig().removeWords().join("\n"));
+  ui.teRemoveLinesWords->setText(
+      config.postProcessingConfig().removeLinesWords().join("\n"));
 
   ui.cbSubFormat->setCurrentIndex(0);
   ui.cbSubExtension->setCurrentIndex(0);

--- a/gui/ui/frmoptions.ui
+++ b/gui/ui/frmoptions.ui
@@ -654,7 +654,7 @@
            </layout>
           </item>
           <item row="5" column="0" colspan="4">
-           <widget class="QTextEdit" name="teRemoveWords">
+           <widget class="QTextEdit" name="teRemoveLinesWords">
             <property name="enabled">
              <bool>false</bool>
             </property>
@@ -763,7 +763,7 @@ p, li { white-space: pre-wrap; }
          </layout>
          <zorder>cbAutoDetectEncoding</zorder>
          <zorder>cbRemoveLines</zorder>
-         <zorder>teRemoveWords</zorder>
+         <zorder>teRemoveLinesWords</zorder>
          <zorder>lbSubFormat</zorder>
          <zorder>cbSubFormat</zorder>
          <zorder>lbSubExtension</zorder>
@@ -844,7 +844,7 @@ p, li { white-space: pre-wrap; }
   <tabstop>cbEncTo</tabstop>
   <tabstop>cbShowAllEncodings</tabstop>
   <tabstop>cbRemoveLines</tabstop>
-  <tabstop>teRemoveWords</tabstop>
+  <tabstop>teRemoveLinesWords</tabstop>
   <tabstop>cbSubFormat</tabstop>
   <tabstop>cbSubExtension</tabstop>
   <tabstop>cbSkipConvertAds</tabstop>
@@ -892,7 +892,7 @@ p, li { white-space: pre-wrap; }
   <connection>
    <sender>cbRemoveLines</sender>
    <signal>toggled(bool)</signal>
-   <receiver>teRemoveWords</receiver>
+   <receiver>teRemoveLinesWords</receiver>
    <slot>setEnabled(bool)</slot>
    <hints>
     <hint type="sourcelabel">

--- a/libqnapi/src/config/configreader.cpp
+++ b/libqnapi/src/config/configreader.cpp
@@ -48,6 +48,17 @@ const QNapiConfig ConfigReader::readConfig(const QSettings& settings) const {
                      settings.value("qnapi/last_opened_dir", "").toString());
 }
 
+QVariant ConfigReader::firstValid(std::initializer_list<QVariant> list)
+{
+    for (const auto& v : list) {
+        if (v.isValid()) {
+            return v;
+        }
+    }
+
+    return QVariant();
+}
+
 const GeneralConfig ConfigReader::readGeneralConfig(
     const QSettings& settings) const {
   QString sysLangCode = QLocale::system().name().left(2);
@@ -134,10 +145,11 @@ const PostProcessingConfig ConfigReader::readPostProcessingConfig(
       settings.value("qnapi/sub_ext", "").toString(),
       settings.value("qnapi/skip_convert_ads", false).toBool(),
       settings.value("qnapi/remove_lines", false).toBool(),
-      settings
-          .value("qnapi/remove_words", QStringList() << "movie info"
-                                                     << "synchro")
-          .toStringList());
+      firstValid({
+                     settings.value("qnapi/remove_lines_words"),
+                     settings.value("qnapi/remove_words"), // Legacy setting
+                     QStringList({ "movie info", "synchro" })
+                 }).toStringList());
 }
 
 const ScanConfig ConfigReader::readScanConfig(const QSettings& settings) const {

--- a/libqnapi/src/config/configreader.h
+++ b/libqnapi/src/config/configreader.h
@@ -19,6 +19,7 @@
 #include <QSettings>
 #include <QSharedPointer>
 #include <QString>
+#include <QVariant>
 
 #include <config/engineconfig.h>
 #include <config/qnapiconfig.h>
@@ -38,6 +39,8 @@ class ConfigReader {
   const QNapiConfig readConfig(const QSettings& settings) const;
 
  private:
+  static QVariant firstValid(std::initializer_list<QVariant> list);
+
   const GeneralConfig readGeneralConfig(const QSettings& settings) const;
   const QList<QPair<QString, bool>> readEnabledEngines(
       const QSettings& settings) const;

--- a/libqnapi/src/config/configwriter.cpp
+++ b/libqnapi/src/config/configwriter.cpp
@@ -104,6 +104,7 @@ void ConfigWriter::writePostProcessingConfig(
   settings.setValue("qnapi/sub_ext", postProcessingConfig.subExtension());
   settings.setValue("qnapi/skip_convert_ads",
                     postProcessingConfig.skipConvertAds());
+  settings.setValue("qnapi/remove_lines", postProcessingConfig.removeLines());
   settings.setValue("qnapi/remove_words", postProcessingConfig.removeWords());
 }
 

--- a/libqnapi/src/config/configwriter.cpp
+++ b/libqnapi/src/config/configwriter.cpp
@@ -105,7 +105,7 @@ void ConfigWriter::writePostProcessingConfig(
   settings.setValue("qnapi/skip_convert_ads",
                     postProcessingConfig.skipConvertAds());
   settings.setValue("qnapi/remove_lines", postProcessingConfig.removeLines());
-  settings.setValue("qnapi/remove_words", postProcessingConfig.removeWords());
+  settings.setValue("qnapi/remove_lines_words", postProcessingConfig.removeLinesWords());
 }
 
 void ConfigWriter::writeScanConfig(const ScanConfig& scanConfig,

--- a/libqnapi/src/config/postprocessingconfig.cpp
+++ b/libqnapi/src/config/postprocessingconfig.cpp
@@ -28,6 +28,6 @@ QString PostProcessingConfig::toString() const {
                   << "subExtension: " << subExtension() << endl
                   << "skipConvertAds: " << skipConvertAds() << endl
                   << "removeLines: " << removeLines() << endl
-                  << "removeWords: " << removeWords().join("; ") << endl;
+                  << "removeLinesWords: " << removeLinesWords().join("; ") << endl;
   return s;
 }

--- a/libqnapi/src/config/postprocessingconfig.cpp
+++ b/libqnapi/src/config/postprocessingconfig.cpp
@@ -27,7 +27,7 @@ QString PostProcessingConfig::toString() const {
                   << "subFormat: " << subFormat() << endl
                   << "subExtension: " << subExtension() << endl
                   << "skipConvertAds: " << skipConvertAds() << endl
-                  << "removeWordsEnabled: " << removeWordsEnabled() << endl
+                  << "removeLines: " << removeLines() << endl
                   << "removeWords: " << removeWords().join("; ") << endl;
   return s;
 }

--- a/libqnapi/src/config/postprocessingconfig.h
+++ b/libqnapi/src/config/postprocessingconfig.h
@@ -36,7 +36,7 @@ class PostProcessingConfig {
   QString subExtension_;
   bool skipConvertAds_;
   bool removeLines_;
-  QStringList removeWords_;
+  QStringList removeLinesWords_;
 
  public:
   PostProcessingConfig(const bool& enabled,
@@ -47,7 +47,7 @@ class PostProcessingConfig {
                        const QString& subFormat, const QString& subExtension,
                        const bool& skipConvertAds,
                        const bool& removeLines,
-                       const QStringList& removeWords)
+                       const QStringList& removeLinesWords)
       : enabled_(enabled),
         encodingChangeMethod_(encodingChangeMethod),
         encodingFrom_(encodingFrom),
@@ -58,7 +58,7 @@ class PostProcessingConfig {
         subExtension_(subExtension),
         skipConvertAds_(skipConvertAds),
         removeLines_(removeLines),
-        removeWords_(removeWords) {}
+        removeLinesWords_(removeLinesWords) {}
 
   bool enabled() const { return enabled_; }
   EncodingChangeMethod encodingChangeMethod() const {
@@ -72,81 +72,81 @@ class PostProcessingConfig {
   QString subExtension() const { return subExtension_; }
   bool skipConvertAds() const { return skipConvertAds_; }
   bool removeLines() const { return removeLines_; }
-  QStringList removeWords() const { return removeWords_; }
+  QStringList removeLinesWords() const { return removeLinesWords_; }
 
   const PostProcessingConfig setEnabled(const bool& enabled) const {
     return PostProcessingConfig(
         enabled, encodingChangeMethod_, encodingFrom_, encodingAutoDetectFrom_,
         encodingTo_, showAllEncodings_, subFormat_, subExtension_,
-        skipConvertAds_, removeLines_, removeWords_);
+        skipConvertAds_, removeLines_, removeLinesWords_);
   }
   const PostProcessingConfig setEncodingChangeMethod(
       const EncodingChangeMethod& encodingChangeMethod) const {
     return PostProcessingConfig(
         enabled_, encodingChangeMethod, encodingFrom_, encodingAutoDetectFrom_,
         encodingTo_, showAllEncodings_, subFormat_, subExtension_,
-        skipConvertAds_, removeLines_, removeWords_);
+        skipConvertAds_, removeLines_, removeLinesWords_);
   }
   const PostProcessingConfig setEncodingFrom(
       const QString& encodingFrom) const {
     return PostProcessingConfig(
         enabled_, encodingChangeMethod_, encodingFrom, encodingAutoDetectFrom_,
         encodingTo_, showAllEncodings_, subFormat_, subExtension_,
-        skipConvertAds_, removeLines_, removeWords_);
+        skipConvertAds_, removeLines_, removeLinesWords_);
   }
   const PostProcessingConfig setEncodingAutoDetectFrom(
       const bool& encodingAutoDetectFrom) const {
     return PostProcessingConfig(
         enabled_, encodingChangeMethod_, encodingFrom_, encodingAutoDetectFrom,
         encodingTo_, showAllEncodings_, subFormat_, subExtension_,
-        skipConvertAds_, removeLines_, removeWords_);
+        skipConvertAds_, removeLines_, removeLinesWords_);
   }
   const PostProcessingConfig setEncodingTo(const QString& encodingTo) const {
     return PostProcessingConfig(
         enabled_, encodingChangeMethod_, encodingFrom_, encodingAutoDetectFrom_,
         encodingTo, showAllEncodings_, subFormat_, subExtension_,
-        skipConvertAds_, removeLines_, removeWords_);
+        skipConvertAds_, removeLines_, removeLinesWords_);
   }
   const PostProcessingConfig setShowAllEncodings(
       const bool& showAllEncodings) const {
     return PostProcessingConfig(
         enabled_, encodingChangeMethod_, encodingFrom_, encodingAutoDetectFrom_,
         encodingTo_, showAllEncodings, subFormat_, subExtension_,
-        skipConvertAds_, removeLines_, removeWords_);
+        skipConvertAds_, removeLines_, removeLinesWords_);
   }
   const PostProcessingConfig setSubFormat(const QString& subFormat) const {
     return PostProcessingConfig(
         enabled_, encodingChangeMethod_, encodingFrom_, encodingAutoDetectFrom_,
         encodingTo_, showAllEncodings_, subFormat, subExtension_,
-        skipConvertAds_, removeLines_, removeWords_);
+        skipConvertAds_, removeLines_, removeLinesWords_);
   }
   const PostProcessingConfig setSubExtension(
       const QString& subExtension) const {
     return PostProcessingConfig(
         enabled_, encodingChangeMethod_, encodingFrom_, encodingAutoDetectFrom_,
         encodingTo_, showAllEncodings_, subFormat_, subExtension,
-        skipConvertAds_, removeLines_, removeWords_);
+        skipConvertAds_, removeLines_, removeLinesWords_);
   }
   const PostProcessingConfig setSkipConvertAds(
       const bool& skipConvertAds) const {
     return PostProcessingConfig(
         enabled_, encodingChangeMethod_, encodingFrom_, encodingAutoDetectFrom_,
         encodingTo_, showAllEncodings_, subFormat_, subExtension_,
-        skipConvertAds, removeLines_, removeWords_);
+        skipConvertAds, removeLines_, removeLinesWords_);
   }
   const PostProcessingConfig setRemoveLines(
       const bool& removeLines) const {
     return PostProcessingConfig(
         enabled_, encodingChangeMethod_, encodingFrom_, encodingAutoDetectFrom_,
         encodingTo_, showAllEncodings_, subFormat_, subExtension_,
-        skipConvertAds_, removeLines, removeWords_);
+        skipConvertAds_, removeLines, removeLinesWords_);
   }
-  const PostProcessingConfig setRemoveWords(
-      const QStringList& removeWords) const {
+  const PostProcessingConfig setRemoveLinesWords(
+      const QStringList& removeLinesWords) const {
     return PostProcessingConfig(
         enabled_, encodingChangeMethod_, encodingFrom_, encodingAutoDetectFrom_,
         encodingTo_, showAllEncodings_, subFormat_, subExtension_,
-        skipConvertAds_, removeLines_, removeWords);
+        skipConvertAds_, removeLines_, removeLinesWords);
   }
 
   QString toString() const;

--- a/libqnapi/src/config/postprocessingconfig.h
+++ b/libqnapi/src/config/postprocessingconfig.h
@@ -35,7 +35,7 @@ class PostProcessingConfig {
   QString subFormat_;
   QString subExtension_;
   bool skipConvertAds_;
-  bool removeWordsEnabled_;
+  bool removeLines_;
   QStringList removeWords_;
 
  public:
@@ -46,7 +46,7 @@ class PostProcessingConfig {
                        const QString& encodingTo, const bool& showAllEncodings,
                        const QString& subFormat, const QString& subExtension,
                        const bool& skipConvertAds,
-                       const bool& removeWordsEnabled,
+                       const bool& removeLines,
                        const QStringList& removeWords)
       : enabled_(enabled),
         encodingChangeMethod_(encodingChangeMethod),
@@ -57,7 +57,7 @@ class PostProcessingConfig {
         subFormat_(subFormat),
         subExtension_(subExtension),
         skipConvertAds_(skipConvertAds),
-        removeWordsEnabled_(removeWordsEnabled),
+        removeLines_(removeLines),
         removeWords_(removeWords) {}
 
   bool enabled() const { return enabled_; }
@@ -71,82 +71,82 @@ class PostProcessingConfig {
   QString subFormat() const { return subFormat_; }
   QString subExtension() const { return subExtension_; }
   bool skipConvertAds() const { return skipConvertAds_; }
-  bool removeWordsEnabled() const { return removeWordsEnabled_; }
+  bool removeLines() const { return removeLines_; }
   QStringList removeWords() const { return removeWords_; }
 
   const PostProcessingConfig setEnabled(const bool& enabled) const {
     return PostProcessingConfig(
         enabled, encodingChangeMethod_, encodingFrom_, encodingAutoDetectFrom_,
         encodingTo_, showAllEncodings_, subFormat_, subExtension_,
-        skipConvertAds_, removeWordsEnabled_, removeWords_);
+        skipConvertAds_, removeLines_, removeWords_);
   }
   const PostProcessingConfig setEncodingChangeMethod(
       const EncodingChangeMethod& encodingChangeMethod) const {
     return PostProcessingConfig(
         enabled_, encodingChangeMethod, encodingFrom_, encodingAutoDetectFrom_,
         encodingTo_, showAllEncodings_, subFormat_, subExtension_,
-        skipConvertAds_, removeWordsEnabled_, removeWords_);
+        skipConvertAds_, removeLines_, removeWords_);
   }
   const PostProcessingConfig setEncodingFrom(
       const QString& encodingFrom) const {
     return PostProcessingConfig(
         enabled_, encodingChangeMethod_, encodingFrom, encodingAutoDetectFrom_,
         encodingTo_, showAllEncodings_, subFormat_, subExtension_,
-        skipConvertAds_, removeWordsEnabled_, removeWords_);
+        skipConvertAds_, removeLines_, removeWords_);
   }
   const PostProcessingConfig setEncodingAutoDetectFrom(
       const bool& encodingAutoDetectFrom) const {
     return PostProcessingConfig(
         enabled_, encodingChangeMethod_, encodingFrom_, encodingAutoDetectFrom,
         encodingTo_, showAllEncodings_, subFormat_, subExtension_,
-        skipConvertAds_, removeWordsEnabled_, removeWords_);
+        skipConvertAds_, removeLines_, removeWords_);
   }
   const PostProcessingConfig setEncodingTo(const QString& encodingTo) const {
     return PostProcessingConfig(
         enabled_, encodingChangeMethod_, encodingFrom_, encodingAutoDetectFrom_,
         encodingTo, showAllEncodings_, subFormat_, subExtension_,
-        skipConvertAds_, removeWordsEnabled_, removeWords_);
+        skipConvertAds_, removeLines_, removeWords_);
   }
   const PostProcessingConfig setShowAllEncodings(
       const bool& showAllEncodings) const {
     return PostProcessingConfig(
         enabled_, encodingChangeMethod_, encodingFrom_, encodingAutoDetectFrom_,
         encodingTo_, showAllEncodings, subFormat_, subExtension_,
-        skipConvertAds_, removeWordsEnabled_, removeWords_);
+        skipConvertAds_, removeLines_, removeWords_);
   }
   const PostProcessingConfig setSubFormat(const QString& subFormat) const {
     return PostProcessingConfig(
         enabled_, encodingChangeMethod_, encodingFrom_, encodingAutoDetectFrom_,
         encodingTo_, showAllEncodings_, subFormat, subExtension_,
-        skipConvertAds_, removeWordsEnabled_, removeWords_);
+        skipConvertAds_, removeLines_, removeWords_);
   }
   const PostProcessingConfig setSubExtension(
       const QString& subExtension) const {
     return PostProcessingConfig(
         enabled_, encodingChangeMethod_, encodingFrom_, encodingAutoDetectFrom_,
         encodingTo_, showAllEncodings_, subFormat_, subExtension,
-        skipConvertAds_, removeWordsEnabled_, removeWords_);
+        skipConvertAds_, removeLines_, removeWords_);
   }
   const PostProcessingConfig setSkipConvertAds(
       const bool& skipConvertAds) const {
     return PostProcessingConfig(
         enabled_, encodingChangeMethod_, encodingFrom_, encodingAutoDetectFrom_,
         encodingTo_, showAllEncodings_, subFormat_, subExtension_,
-        skipConvertAds, removeWordsEnabled_, removeWords_);
+        skipConvertAds, removeLines_, removeWords_);
   }
-  const PostProcessingConfig setRemoveWordsEnabled(
-      const bool& removeWordsEnabled) const {
+  const PostProcessingConfig setRemoveLines(
+      const bool& removeLines) const {
     return PostProcessingConfig(
         enabled_, encodingChangeMethod_, encodingFrom_, encodingAutoDetectFrom_,
         encodingTo_, showAllEncodings_, subFormat_, subExtension_,
-        skipConvertAds_, removeWordsEnabled, removeWords_);
+        skipConvertAds_, removeLines, removeWords_);
   }
   const PostProcessingConfig setRemoveWords(
       const QStringList& removeWords) const {
     return PostProcessingConfig(
         enabled_, encodingChangeMethod_, encodingFrom_, encodingAutoDetectFrom_,
         encodingTo_, showAllEncodings_, subFormat_, subExtension_,
-        skipConvertAds_, removeWordsEnabled_, removeWords);
+        skipConvertAds_, removeLines_, removeWords);
   }
 
   QString toString() const;

--- a/libqnapi/src/subtitlepostprocessor.cpp
+++ b/libqnapi/src/subtitlepostprocessor.cpp
@@ -27,7 +27,7 @@ SubtitlePostProcessor::SubtitlePostProcessor(
 void SubtitlePostProcessor::perform(const QString& movieFilePath,
                                     const QString& subtitleFilePath) const {
   if (ppConfig.removeLines()) {
-    ppRemoveLinesContainingWords(subtitleFilePath, ppConfig.removeWords());
+    ppRemoveLinesContainingWords(subtitleFilePath, ppConfig.removeLinesWords());
   }
 
   switch (ppConfig.encodingChangeMethod()) {

--- a/libqnapi/src/subtitlepostprocessor.cpp
+++ b/libqnapi/src/subtitlepostprocessor.cpp
@@ -26,7 +26,7 @@ SubtitlePostProcessor::SubtitlePostProcessor(
 
 void SubtitlePostProcessor::perform(const QString& movieFilePath,
                                     const QString& subtitleFilePath) const {
-  if (ppConfig.removeWordsEnabled()) {
+  if (ppConfig.removeLines()) {
     ppRemoveLinesContainingWords(subtitleFilePath, ppConfig.removeWords());
   }
 


### PR DESCRIPTION
Additionally, rename associated 'cbRemoveLines' to 'cbRemoveWords' in frmOptions to match the PostProcessingConfig setting.