### PR TITLE
Define subtarget INSTALLS in each of subtarget's .pro

### DIFF
--- a/cli/cli.pro
+++ b/cli/cli.pro
@@ -20,11 +20,12 @@ RCC_DIR = tmp
 OBJECTS_DIR = tmp
 INCLUDEPATH = src
 
+include(../qnapi.pri)
 include(../libqnapi/libqnapi.pri)
 
 unix {
     TARGET = qnapic
-    DESTDIR = ../
+    DESTDIR = $${OUTDIR}
     CONFIG += link_pkgconfig
     PKGCONFIG += libmediainfo
 }
@@ -37,11 +38,16 @@ macx {
     QMAKE_CXXFLAGS_X86_64 = -mmacosx-version-min=10.8
 }
 
-win32 {
-    CONFIG += nostrip
-    RC_FILE = ../win32/qnapi.rc
-    TARGET = qnapic
-    target.path = ../win32/out
+!win32 {
+    target.path = $${INSTALL_PREFIX}/bin
     INSTALLS += target
 }
 
+win32 {
+    CONFIG += nostrip
+    RC_FILE = $${OUTDIR}/qnapi.rc
+    TARGET = qnapic
+
+    target.path = $${INSTALL_PREFIX}
+    INSTALLS += target
+}

--- a/gui/gui.pro
+++ b/gui/gui.pro
@@ -63,6 +63,7 @@ RCC_DIR = tmp
 OBJECTS_DIR = tmp
 INCLUDEPATH = src
 
+include(../qnapi.pri)
 include(../libqnapi/libqnapi.pri)
 
 unix:!macx {
@@ -77,31 +78,37 @@ macx {
     HEADERS += src/utils/infoplistdockicon.h
 
     TARGET = QNapi
-    DESTDIR = ../macx/
+    DESTDIR = $${OUTDIR}
 
     LIBS += -framework CoreFoundation
     QMAKE_MACOSX_DEPLOYMENT_TARGET = 10.8
     QMAKE_CXXFLAGS_X86_64 = -mmacosx-version-min=10.8
-    ICON = ../macx/qnapi.icns
-    QMAKE_INFO_PLIST = ../macx/Info.plist
-    7ZIP_BINARY.files = ../macx/content/7za
+    ICON = $${OUTDIR}/qnapi.icns
+    QMAKE_INFO_PLIST = $${OUTDIR}/Info.plist
+    7ZIP_BINARY.files = $${OUTDIR}/content/7za
     7ZIP_BINARY.path = Contents/Resources
     LIBMEDIAINFO.files = ../deps/libmediainfo/lib/libmediainfo.0.dylib
     LIBMEDIAINFO.path = Contents/MacOS
     QMAKE_BUNDLE_DATA += 7ZIP_BINARY LIBMEDIAINFO
 }
 
+!win32 {
+    SOURCES += src/qcumber/qinterprocesschannel.cpp
+    HEADERS += src/qcumber/qinterprocesschannel.h
+
+    !macx {
+        target.path = $${INSTALL_PREFIX}/bin
+        INSTALLS += target
+    }
+}
+
 win32 {
     CONFIG += nostrip
     SOURCES += src/qcumber/qinterprocesschannel_win32.cpp
     HEADERS += src/qcumber/qinterprocesschannel_win32.h
-    RC_FILE = ../win32/qnapi.rc
+    RC_FILE = $${OUTDIR}/qnapi.rc
     TARGET = qnapi
-    target.path = ../win32/out
-    INSTALLS += target
-}
 
-!win32 { 
-    SOURCES += src/qcumber/qinterprocesschannel.cpp
-    HEADERS += src/qcumber/qinterprocesschannel.h
+    target.path = $${INSTALL_PREFIX}
+    INSTALLS += target
 }

--- a/qnapi.pri
+++ b/qnapi.pri
@@ -1,0 +1,13 @@
+unix:!macx {
+    OUTDIR = $${PWD}
+    INSTALL_PREFIX = /usr
+}
+
+macx {
+    OUTDIR = $${PWD}/macx
+}
+
+win32 {
+    OUTDIR = $${PWD}/win32
+    INSTALL_PREFIX = $${OUTDIR}/out
+}

--- a/qnapi.pro
+++ b/qnapi.pro
@@ -12,21 +12,10 @@ no_gui:SUBDIRS -= gui
 
 TRANSLATIONS += translations/qnapi_it.ts translations/qnapi_pl.ts
 
+include(qnapi.pri)
+
 unix {
-    INSTALL_PREFIX = /usr
     DATADIR=$${INSTALL_PREFIX}/share
-
-    !no_cli {
-        cli_target.files = qnapic
-        cli_target.path = $${INSTALL_PREFIX}/bin
-        INSTALLS += cli_target
-    }
-
-    !macx:!no_gui {
-        gui_target.files = qnapi
-        gui_target.path = $${INSTALL_PREFIX}/bin
-        INSTALLS += gui_target
-    }
 
     doc.path = $${INSTALL_PREFIX}/share/doc/qnapi
     doc.files = doc/ChangeLog \
@@ -69,8 +58,6 @@ macx:!no_gui {
 }
 
 win32 {
-    INSTALL_PREFIX = win32/out
-
     QMAKE_STRIP = echo
 
     p7zip.files = win32/content/7za.exe
@@ -91,8 +78,8 @@ win32 {
 
     DEPLOYWIN_FLAGS = --no-translations --no-quick-import --no-system-d3d-compiler --no-angle --no-webkit --no-webkit2
     deploywin.commands += windeployqt $${DEPLOYWIN_FLAGS}
-    !no_cli:deploywin.commands += win32/out/qnapic.exe
-    !no_gui:deploywin.commands += win32/out/qnapi.exe
+    !no_cli:deploywin.commands += $${INSTALL_PREFIX}/qnapic.exe
+    !no_gui:deploywin.commands += $${INSTALL_PREFIX}/qnapi.exe
 
     platform.files = $$[QT_INSTALL_PLUGINS]/platforms/qwindows.dll
     platform.path = $${INSTALL_PREFIX}/platforms


### PR DESCRIPTION
While creating a **QNapi** package I noticed that while `qnapic` binary was being produced, it never got copied to the installation directory, nor ended up in the package as a result. The immediate reason for it was the lack of associated rule in the `Makefile` produced by `qmake`.

`qmake`'s debug log for the main `qnapi.pro` unveiled the following:

>DEBUG 1: /build/qt5-base/src/qtbase-everywhere-src-5.10.1/qmake/generators/makefile.cpp:321 Failure to find qnapic in vpath ()
>DEBUG 1: **no definition for install cli_target: install target not created**
>DEBUG 1: /build/qt5-base/src/qtbase-everywhere-src-5.10.1/qmake/generators/makefile.cpp:321 Failure to find qnapi in vpath ()

Apparently, the only reason why even `gui_target` was getting installed was due to filename similarity between the final binary (`qnapi`) and the main `qnapi.pro`.

To circumvent these issues I decided to define install targets in their own `.pro` files, combining that with a common `qnapi.pri` with definitions of platform-specific directories shared between them.