### PR TITLE
Fix: Searching in OpenSubtitles.org and Napisy24 not working for files larger then 2GiB

### DIFF
--- a/libqnapi/src/engines/napisy24downloadengine.cpp
+++ b/libqnapi/src/engines/napisy24downloadengine.cpp
@@ -60,7 +60,7 @@ QString Napisy24DownloadEngine::checksum(QString filename) {
        i < 65536 / sizeof(tmp) && file.read((char *)&tmp, sizeof(tmp));
        i++, hash += tmp)
     ;
-  file.seek(qMax(0, (int)((qint64)fileSize - 65536)));
+  file.seek(qMax((qint64)0, (qint64)fileSize - 65536));
   for (tmp = 0, i = 0;
        i < 65536 / sizeof(tmp) && file.read((char *)&tmp, sizeof(tmp));
        i++, hash += tmp)

--- a/libqnapi/src/engines/opensubtitlesdownloadengine.cpp
+++ b/libqnapi/src/engines/opensubtitlesdownloadengine.cpp
@@ -67,7 +67,7 @@ QString OpenSubtitlesDownloadEngine::checksum(QString filename) {
        i < 65536 / sizeof(tmp) && file.read((char*)&tmp, sizeof(tmp));
        i++, hash += tmp)
     ;
-  file.seek(qMax(0, (int)((qint64)fileSize - 65536)));
+  file.seek(qMax((qint64)0, (qint64)fileSize - 65536));
   for (tmp = 0, i = 0;
        i < 65536 / sizeof(tmp) && file.read((char*)&tmp, sizeof(tmp));
        i++, hash += tmp)
@@ -84,7 +84,7 @@ bool OpenSubtitlesDownloadEngine::lookForSubtitles(QString lang) {
   QVariantMap paramsMap;
   paramsMap["sublanguageid"] = SubtitleLanguage(lang).toTriLetter();
   paramsMap["moviehash"] = checkSum;
-  paramsMap["moviebytesize"] = (int)fileSize;
+  paramsMap["moviebytesize"] = QString::number(fileSize);
 
   QVariantList requestList;
   requestList << paramsMap;


### PR DESCRIPTION
Due to integer overflow, searching for subtitles in OpenSubtitles.org and Napisy24 never yielded any results for files larger the 2GiB.

The exact problem is that a signed, 32-bit integer is used when calculating offset in a video file from which to read bytes that feed checksum calculation. This results in wrong checksum if size of the file exceeds ~2GiB.

There is also another problem specific to OpenSubtitles.org - the overall size of the video file is being send to OpenSubtitles.org as a 32-bit signed integer which causes overflow and a wrong number being send.

This pull request fixes the issue by using 64-bit integers when calculating checksum and sending video file size to OpenSubtitles.org as a string.

I tested the bug and the fix on these files (replace [COLON] with a colon):
`magnet[COLON]?xt=urn:btih:408ceb0d4ed6a2fb96d494f63c6650087dd0759f&dn=Homeland.S03.1080p.AMZN.WEBRip.DDP5.1.x265-SiGMA%5brartv%5d&tr=udp%3a%2f%2ftracker.coppersurfer.tkg%3a6969%2fannounce&tr=http%3a%2f%2ftracker.trackerfix.com%3a80%2fannounce&tr=udp%3a%2f%2fexplodie.org%3a6969%2fannounce&tr=udp%3a%2f%2ftracker.opentrackr.org%3a1337%2fannounce&tr=udp%3a%2f%2ftracker.internetwarriors.net%3a1337%2fannounce&tr=udp%3a%2f%2f9.rarbg.me%3a2710&tr=udp%3a%2f%2f9.rarbg.to%3a2710&tr=udp%3a%2f%2ftracker.leechers-paradise.org%3a6969%2fannounce&tr=udp%3a%2f%2fopen.demonii.com%3a1337%2fannounce&tr=udp%3a%2f%2ftracker.coppersurfer.tk%3a6969%2fannounce&tr=udp%3a%2f%2ftracker.pirateparty.gr%3a6969%2fannounce&tr=udp%3a%2f%2ftracker.cyberia.is%3a6969%2fannounce&tr=udp%3a%2f%2fopen.demonii.si%3a1337%2fannounce&tr=udp%3a%2f%2fopen.stealth.si%2fannounce&tr=udp%3a%2f%2fexodus.desync.com%3a6969%2fannounce&tr=http%3a%2f%2fexplodie.org%3a6969%2fannounce&tr=https%3a%2f%2ftracker.cyber-hub.net%2fannounce&tr=udp%3a%2f%2f9.rarbg.me%3a2740%2fannounce&tr=udp%3a%2f%2f9.rarbg.to%3a2790%2fannounce`
Try English subtitles from OpenSubtitles.org and Polish subtitles from Napisy24 for S03E12. You don't have to download everything, first and last 64KiB of the file is enough (use e.g. qBittorrent to download only the  front and the back of a file).

You can also test the checksum calculation on exemplary "DUMMY RAR file" provided by OpenSubtitles.org, get it here:
https://trac.opensubtitles.org/projects/opensubtitles/wiki/HashSourceCodes
NOTE: c++ implementation of the checksum algorithm on the above page is invalid and suffers from the same integer overflow bug.