### PR TITLE
Fix: Download process not starting if qnapi is already in tray

### DIFF
--- a/gui/src/qnapiapp.cpp
+++ b/gui/src/qnapiapp.cpp
@@ -47,6 +47,14 @@ QNapiApp::QNapiApp(int &argc, char **argv, const QString &appName)
   napisy24SubMenu = 0;
   trayIconMenu = 0;
   trayIcon = 0;
+
+  connect(
+      this, &QNapiApp::downloadFile,
+      this, [this] (const QString &path) { progress()->receiveRequest(path); });
+
+  connect( // ### Qt 5.7 use QOverload
+      this, static_cast<void (QNapiApp::*)(const QString&)>(&QNapiApp::request),
+      this, &QNapiApp::downloadFile);
 }
 
 QNapiApp::~QNapiApp() {
@@ -80,10 +88,6 @@ frmProgress *QNapiApp::progress() {
   if (!f_progress) {
     f_progress = new frmProgress();
     if (!f_progress) abort();
-    connect(this, SIGNAL(request(QString)), f_progress,
-            SLOT(receiveRequest(QString)));
-    connect(this, SIGNAL(downloadFile(const QString &)), f_progress,
-            SLOT(receiveRequest(const QString &)));
   }
   return f_progress;
 }


### PR DESCRIPTION
Steps to reproduce:
 - start QNapi, it should appear in tray
 - start QNapi again, this time passing a movie file either by using "open with" in a file manager or by command line
 - observe the fact that download process is not starting

Cause:
When starting QNapi process with a movie file passed as a command line argument, QNapi first tries to find out if another instance is running. If that's the case, it notifies the other instance about requested movie file and quits. When the other instance receives the request it starts the download process. However, the signal-slot connection that binds the request to the download process is created when _frmProgress_ form is first created.

https://github.com/QNapi/qnapi/blob/d4e0378a601838a96b7ee25ff48a8eaf18388fcd/gui/src/qnapiapp.cpp#L79-L89

If the form wasn't created yet (and that's the case if QNapi was only started in the tray), the request doesn't go through.

Proposed solution (implemented in this PR):
Create _frmProgress_ form when receiving a request from other QNapi instance.