### PR TITLE
Write subtitle files with an appended languageCode for use with plex and

### DIFF
--- a/cli/src/clisubtitlesdownloader.cpp
+++ b/cli/src/clisubtitlesdownloader.cpp
@@ -163,7 +163,7 @@ int finishSubtitles(int selIdx, const Console& c, QNapi& napi) {
   }
 
   c.printLineOrdinary(tr("Adjusting subtitles..."));
-  if (!napi.matchSubtitles()) {
+  if (!napi.matchSubtitles(selIdx)) {
     c.printLineError(tr("Could not adjust subtitles!"));
     return EC_COULD_NOT_MATCH;
   }

--- a/gui/src/forms/frmprogress.cpp
+++ b/gui/src/forms/frmprogress.cpp
@@ -387,7 +387,7 @@ void GetThread::run() {
     emit progressChange(i, queue.size(), 0.9f);
     emit actionChange(tr("Adjusting subtitles..."));
 
-    if (!napi.matchSubtitles()) {
+    if (!napi.matchSubtitles(selIdx)) {
       ABORT_POINT
 
       ++napiFail;

--- a/gui/src/forms/frmscan.cpp
+++ b/gui/src/forms/frmscan.cpp
@@ -236,7 +236,10 @@ void frmScan::accept() {
   QDialog::accept();
 }
 
-ScanFilesThread::ScanFilesThread() : staticConfig(LibQNapi::staticConfig()) {}
+ScanFilesThread::ScanFilesThread() : staticConfig(LibQNapi::staticConfig()) {
+    const QNapiConfig config = LibQNapi::loadConfig();
+    langCode = config.generalConfig().language();
+}
 
 void ScanFilesThread::run() {
   abort = false;
@@ -278,7 +281,8 @@ bool ScanFilesThread::doScan(const QString &path, QDir::Filters filters) {
       if (skipIfSubtitlesExists) {
         foreach (QString subExt, staticConfig->subtitleExtensions()) {
           if (QFile::exists((*p).absolutePath() + "/" +
-                            (*p).completeBaseName() + "." + subExt)) {
+                            (*p).completeBaseName() +
+                            "." + langCode + "." + subExt)) {
             subtitleFileFound = true;
             break;
           }

--- a/gui/src/forms/frmscan.h
+++ b/gui/src/forms/frmscan.h
@@ -57,6 +57,7 @@ class ScanFilesThread : public QNapiThread {
   QStringList scanFilters, skipFilters;
   bool skipIfSubtitlesExists, followSymLinks;
   QSet<QString> visited;
+  QString langCode;
 };
 
 class frmScan : public QDialog {

--- a/libqnapi/src/qnapi.cpp
+++ b/libqnapi/src/qnapi.cpp
@@ -154,12 +154,14 @@ bool QNapi::unpack(int i) {
   return currentEngine ? currentEngine->unpack(subtitlesList[i].id) : false;
 }
 
-bool QNapi::matchSubtitles() {
+bool QNapi::matchSubtitles(int i) {
   if (currentEngine) {
     QSharedPointer<const SubtitleMatcher> matcher =
         LibQNapi::subtitleMatcher(config);
+    QString lang = subtitlesList[i].lang;
     return matcher->matchSubtitles(currentEngine->subtitlesTmp,
-                                   currentEngine->movie);
+                                   currentEngine->movie,
+                                   lang);
   }
 
   return false;

--- a/libqnapi/src/qnapi.h
+++ b/libqnapi/src/qnapi.h
@@ -51,7 +51,7 @@ class QNapi {
 
   bool download(int i);
   bool unpack(int i);
-  bool matchSubtitles();
+  bool matchSubtitles(int i);
   void postProcessSubtitles() const;
 
   void cleanup();

--- a/libqnapi/src/subtitlematcher.cpp
+++ b/libqnapi/src/subtitlematcher.cpp
@@ -30,7 +30,8 @@ SubtitleMatcher::SubtitleMatcher(
       subtitleFormatsRegistry(subtitleFormatsRegistry) {}
 
 bool SubtitleMatcher::matchSubtitles(QString subtitlesTmpFilePath,
-                                     QString targetMovieFilePath) const {
+                                     QString targetMovieFilePath,
+                                     QString language) const {
   QFileInfo subtitlesTmpFileInfo(subtitlesTmpFilePath);
 
   if (!subtitlesTmpFileInfo.exists()) return false;
@@ -38,12 +39,11 @@ bool SubtitleMatcher::matchSubtitles(QString subtitlesTmpFilePath,
   QString targetExtension = selectTargetExtension(subtitlesTmpFileInfo);
 
   QString targetSubtitlesFilePath =
-      constructSubtitlePath(targetMovieFilePath, targetExtension);
+      constructSubtitlePath(targetMovieFilePath, targetExtension, language);
 
   if (!isWritablePath(targetSubtitlesFilePath)) return false;
 
   removeOrCopy(targetMovieFilePath, targetSubtitlesFilePath);
-
   bool result = false;
 
 #ifdef Q_OS_WIN
@@ -79,10 +79,10 @@ QString SubtitleMatcher::selectTargetExtension(
 
 QString SubtitleMatcher::constructSubtitlePath(QString targetMovieFilePath,
                                                QString targetExtension,
-                                               QString baseSuffix) const {
+                                               QString language) const {
   QFileInfo targetMovieFileInfo(targetMovieFilePath);
   return targetMovieFileInfo.path() + QDir::separator() +
-         targetMovieFileInfo.completeBaseName() + baseSuffix + "." +
+         targetMovieFileInfo.completeBaseName() + "." + language + "." +
          targetExtension;
 }
 

--- a/libqnapi/src/subtitlematcher.h
+++ b/libqnapi/src/subtitlematcher.h
@@ -30,7 +30,8 @@ class SubtitleMatcher : public QObject {
                       &subtitleFormatsRegistry);
 
   bool matchSubtitles(QString subtitlesTmpFilePath,
-                      QString targetMovieFilePath) const;
+                      QString targetMovieFilePath,
+                      QString language) const;
 
  private:
   QString selectTargetExtension(QFileInfo subtitlesTmpFileInfo) const;

--- a/libqnapi/src/version.h
+++ b/libqnapi/src/version.h
@@ -15,8 +15,8 @@
 #ifndef __VERSION__H__
 #define __VERSION__H__
 
-#define QNAPI_VERSION "0.2.4"
-#define QNAPI_DISPLAYABLE_VERSION "0.2.4-snapshot"
+#define QNAPI_VERSION "0.2.5"
+#define QNAPI_DISPLAYABLE_VERSION "0.2.5-snapshot"
 #define QNAPI_URL "http://qnapi.github.io"
 
 #endif


### PR DESCRIPTION
I originally wrote code to support this as an option in the post processing step, but I was 3 layers down in passing configs down to to the subtitleconversion only to realize that this only affects the output file writing in subtitlematcher when I realized this behavior is probably better default behavior anyway, so I removed the config option.

Still not sure how it works with alt languages, because I could not get any alternative languages to ever be found.